### PR TITLE
Throw an error to rather than set to unauthorized value

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,7 +81,7 @@ const getHashiCorpSecret = async function fetchData (hcToken, hcUrl, hcKvVersion
                 if (error.response.status == 404) {
                     secretValue = notFound;
                 } else if (error.response.status == 403) {
-                    secretValue = "[Vault token is expired or not authorized to access the secret]";
+                    throw new Error(`Vault token is expired or not authorized to access the secret`);
                 }
             }
         }


### PR DESCRIPTION
This will fix the issue where if the token is invalid or unauthorized insomnia will cache that as the value for the token and require restarting the application to reset the value.